### PR TITLE
made a few changes to the comments and added option to do resampling …

### DIFF
--- a/src/applications/Preprocessing/src/Preprocessing.cxx
+++ b/src/applications/Preprocessing/src/Preprocessing.cxx
@@ -15,6 +15,7 @@ enum AvailableAlgorithms
   None,
   HistogramMatching,
   Resize,
+  Resample,
   SanityCheck,
   Information,
   Casting,
@@ -26,10 +27,11 @@ enum AvailableAlgorithms
 
 int requestedAlgorithm = 0;
 
-std::string inputImageFile, inputMaskFile, outputImageFile, targetImageFile;
+std::string inputImageFile, inputMaskFile, outputImageFile, targetImageFile, resamplingInterpolator;
 size_t resize = 100;
 int histoMatchQuantiles = 40, histoMatchBins = 100, testRadius = 0, testNumber = 0;
 float testThresh = 0.0, testAvgDiff = 0.0;
+float resamplingResolution = 1.0;
 float zNormCutLow = 3, zNormCutHigh = 3, zNormQuantLow = 5, zNormQuantHigh = 95;
 
 bool uniqueValsSort = true, boundingBoxIsotropic = true;
@@ -37,12 +39,21 @@ bool uniqueValsSort = true, boundingBoxIsotropic = true;
 template< class TImageType >
 int algorithmsRunner()
 {
-  if ((requestedAlgorithm == Resize) && (resize != 100))
+  if (requestedAlgorithm == Resize)
   {
     auto outputImage = cbica::ResizeImage< TImageType >(cbica::ReadImage< TImageType >(inputImageFile), resize);
     cbica::WriteImage< TImageType >(outputImage, outputImageFile);
 
     std::cout << "Resizing by a factor of " << resize << "% completed.\n";
+    return EXIT_SUCCESS;
+  }
+
+  if (requestedAlgorithm == Resample)
+  {
+    auto outputImage = cbica::ResampleImage< TImageType >(cbica::ReadImage< TImageType >(inputImageFile), resamplingResolution, resamplingInterpolator);
+    cbica::WriteImage< TImageType >(outputImage, outputImageFile);
+
+    std::cout << "Resampled image to isotropic resolution of '" << resamplingResolution << "' using interpolator '" << resamplingInterpolator << "'.\n";
     return EXIT_SUCCESS;
   }
 
@@ -457,7 +468,9 @@ int main(int argc, char** argv)
   parser.addOptionalParameter("i", "inputImage", cbica::Parameter::FILE, "NIfTI", "Input Image for processing");
   parser.addOptionalParameter("m", "maskImage", cbica::Parameter::FILE, "NIfTI", "Input Mask for processing");
   parser.addOptionalParameter("o", "outputImage", cbica::Parameter::FILE, "NIfTI", "Output Image for processing");
-  parser.addOptionalParameter("r", "resize", cbica::Parameter::INTEGER, "10-500", "Resize an image based on the resizing factor given", "Example: -r 150 resizes inputImage by 150%", "Defaults to 100, i.e., no resizing");
+  parser.addOptionalParameter("r", "resize", cbica::Parameter::INTEGER, "10-500", "Resize an image based on the resizing factor given", "Example: -r 150 resizes inputImage by 150%", "Defaults to 100, i.e., no resizing", "Resampling can be done on image with 100");
+  parser.addOptionalParameter("rr", "resizeResolution", cbica::Parameter::FLOAT, "0-10", "[Resample] Isotropic resolution of the voxels/pixels to change to", "Resize value needs to be 100", "Defaults to 1.0");
+  parser.addOptionalParameter("ri", "resizeInterp", cbica::Parameter::STRING, "NEAREST:LINEAR:BSPLINE", "[Resample] The interpolation type to use for resampling", "Resize value needs to be 100", "Defaults to LINEAR");
   parser.addOptionalParameter("s", "sanityCheck", cbica::Parameter::FILE, "NIfTI Reference", "Do sanity check of inputImage with the file provided in with this parameter", "Performs checks on size, origin & spacing",
     "Pass the target image after '-s'");
   parser.addOptionalParameter("inf", "information", cbica::Parameter::BOOLEAN, "true or false", "Output the information in inputImage");
@@ -515,7 +528,22 @@ int main(int argc, char** argv)
   if (parser.isPresent("r"))
   {
     parser.getParameterValue("r", resize);
-    requestedAlgorithm = Resize;
+    if (resize != 100)
+    {
+      requestedAlgorithm = Resize;
+    }
+    else
+    {
+      requestedAlgorithm = Resample;
+      if (parser.isPresent("ri"))
+      {
+        parser.getParameterValue("ri", resamplingInterpolator);
+      }
+      if (parser.isPresent("rr"))
+      {
+        parser.getParameterValue("rr", resamplingResolution);
+      }
+    }
   }
   if (parser.isPresent("s"))
   {

--- a/src/cbica_toolkit/src/cbicaITKUtilities.h
+++ b/src/cbica_toolkit/src/cbicaITKUtilities.h
@@ -962,7 +962,7 @@ namespace cbica
   This filter uses the example https://itk.org/Wiki/ITK/Examples/ImageProcessing/ResampleImageFilter as a base while processing time-stamped images as well
   \param inputImage The input image to process
   \param resizeFactor The resize factor; can be greater than 100 (which causes an expanded image to be written) but can never be less than zero
-  \param interpolator The type of interpolator to use; can be Linear, BSplie or NearestNeighbor
+  \param interpolator The type of interpolator to use; can be Linear, BSpline or NearestNeighbor
   \return The resized image
   */
   template< class TImageType = ImageTypeFloat3D >
@@ -1020,7 +1020,13 @@ namespace cbica
   }
 
   /**
-  \brief Resample an image to an isotropic resolution using the specified output spacing
+  \brief Resample an image to an isotropic resolution using the specified output spacing without changing the size
+
+  This filter uses the example https://itk.org/Wiki/ITK/Examples/ImageProcessing/ResampleImageFilter as a base while processing time-stamped images as well
+  \param inputImage The input image to process
+  \param outputSpacing The output spacing, always isotropic
+  \param interpolator The type of interpolator to use; can be Linear, BSpline or NearestNeighbor
+  \return The resized image
   */
   template< class TImageType = ImageTypeFloat3D >
   typename TImageType::Pointer ResampleImage(const typename TImageType::Pointer inputImage, const float outputSpacing = 1.0, const std::string interpolator = "Linear")
@@ -1058,6 +1064,11 @@ namespace cbica
     if (interpolator_wrap == "bspline")
     {
       auto interpolatorFunc = typename itk::BSplineInterpolateImageFunction< TImageType, double >::New();
+      resampler->SetInterpolator(interpolatorFunc);
+    }
+    else if (interpolator_wrap.find("nearest") != std::string::npos)
+    {
+      auto interpolatorFunc = typename itk::NearestNeighborInterpolateImageFunction< TImageType, double >::New();
       resampler->SetInterpolator(interpolatorFunc);
     }
     else 


### PR DESCRIPTION
New replacement for CBICA_utilities. Contains codes relevant to doing resampling (currently only supporting isotropic (e.g. resize of 100 and resizeResolution of 2 will give 2:2:2 resolution image with same physical dimensions as the original input image.) Useful for preprocessing of images prior to throwing into FE for IBSI testing.