### PR TITLE
Extra changes to easily calculate distance value min max as largest distance of bounding box

### DIFF
--- a/src/applications/FeatureExtraction/src/FeatureExtraction.h
+++ b/src/applications/FeatureExtraction/src/FeatureExtraction.h
@@ -659,7 +659,10 @@ private:
     myfile << comments << "\n";
     myfile.close();
   }
-  
+
+  //! This is used to calculate the maximum possible distance in the defined ROI - useful for GLRLM and NGLDM calculations
+  float GetMaximumDistanceWithinTheDefinedROI(const typename TImageType::Pointer itkImage, const typename TImageType::Pointer maskImage);
+    
   // member variables
   cbica::Statistics< typename TImageType::PixelType > m_statistics_local; //! this is for the intensity features
   typename TImageType::PixelType m_minimumToConsider, m_maximumToConsider;

--- a/src/applications/FeatureExtraction/src/depends/NGLDMFeatures.h
+++ b/src/applications/FeatureExtraction/src/depends/NGLDMFeatures.h
@@ -186,17 +186,10 @@ public:
 	//! Default destructor
 	~NGLDMFeatures() { };
 
-	/**
-	\brief Set the range/Chebyshev Distance (how far from the center index of interest do you want to calculate neighborhood level dependence); defaults to 1
-
-	\IBSI calls this value Chebyshev Distance Delta.
-
-	\param rangeValue integer value for the value you want for range
-	**/
-	void SetRange(int rangeValue)
-	{
-		m_range = rangeValue;
-	}
+  void SetDistanceMax(const double maxDistance)
+  {
+    m_maxDistance = maxDistance;
+  }
 
 	/**
 	\brief Set the courseness/alpha parameter (How much difference between the grey levels of the neighbouring voxels do you consider to be dependent); defaults to 0 as typical choice for couraseness
@@ -580,10 +573,6 @@ private:
 
 	}
 
-	//variables
-	unsigned int m_range = 1;
-	typename TImageType::SizeType m_radius;
-
 	//double m_minimumRange;
 	//double m_maximumRange;
 	//double m_Stepsize;
@@ -596,6 +585,11 @@ private:
 	//unsigned long m_NumberOfNeighbourhoods;
 	//unsigned long m_NumberOfCompleteNeighbourhoods;
 
-	//private:
+	private:
+    double m_maxDistance = -1;
+
+    //variables
+    unsigned int m_range = 1;
+    typename TImageType::SizeType m_radius;
 
 };


### PR DESCRIPTION
Fixes issue #(Enter issue number here)

## Proposed Changes
  - bounding box used for max distance calculation now
  - also has same value available in NGLDM
  - mitk namespace in NGLDM needs to change to something like "cbica"